### PR TITLE
BUG: Bold and italics hints are switched

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -151,9 +151,9 @@
                     <dt>Definition Links</dt>
                     <dd>[Text to show](#the word)</dd>
                     <dt>Bold</dt>
-                    <dd>_bold_</dd>
+                    <dd>__bold__</dd>
                     <dt>Italics</dt>
-                    <dd>__italics__</dd>
+                    <dd>_italics_</dd>
                     <dt>Code</dt>
                     <dd>`code`</dd>
                 </dl>


### PR DESCRIPTION
Fix hints for bold and italic embellishments. 
See https://daringfireball.net/projects/markdown/syntax#em